### PR TITLE
wait for get_weather() to not return None

### DIFF
--- a/scripts/weather/main.py
+++ b/scripts/weather/main.py
@@ -1,6 +1,6 @@
 import argparse
 import os
-
+import time
 import requests
 
 OPENWEATHER_URL = "https://api.openweathermap.org/data/2.5/weather"
@@ -100,13 +100,19 @@ def main() -> None:
     lang = args.lang[0] if args.lang else "en"
     unit = args.unit[0] if args.unit else "standard"
 
-    weather = get_weather(city, lang, unit, api_key)
-    if weather:
-        temp, desc = weather.values()
-        if args.verbose:
-            print(f"{temp}, {desc}")
-        else:
-            print(f"{temp}")
+    while True:
+        weather = get_weather(city, lang, unit, api_key)
+
+        if weather:
+            temp, desc = weather.values()
+            break
+
+        time.sleep(1)
+
+    if args.verbose:
+        print(f"{temp}, {desc}")
+    else:
+        print(f"{temp}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I was having an issue on my system where the weather module wasn't displaying on login while using the lofi theme. At the subsequent interval (as defined in `themes/lofi/modules/weather.ini`), the temperature and icon would suddenly appear. I tracked this down to the `get_weather` function in scripts/weather/main.py returning `None`. 

In this pull request, I add code that waits for `get_weather` to return a dictionary of values before proceeding. I did not track down the cause of `get_weather` returning `None` shortly after login, so that remains a mystery.